### PR TITLE
Add verbose Option to design.max_orthogonality and Update Version Number

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "seqwalk"
-version = "0.3.1"
+version = "0.3.2"
 description = "Design orthogonal DNA sequences"
 authors = ["Gokul Gowri"]
 license = "MIT"

--- a/src/seqwalk/design.py
+++ b/src/seqwalk/design.py
@@ -54,7 +54,7 @@ def max_size(L, k, alphabet="ACT", RCfree=False, GClims=None,
 
 def max_orthogonality(N, L, alphabet="ACT", RCfree=False, GClims=None,
                       prevented_patterns=["AAAA", "CCCC", "GGGG","TTTT"],
-                      k_init=None):
+                      k_init=None, verbose=True):
     """
     design a maximally orthogonal library of N length L sequences
 
@@ -66,6 +66,7 @@ def max_orthogonality(N, L, alphabet="ACT", RCfree=False, GClims=None,
         GClims: tuple of (GCmin, GCmax), allowable range of number of GC bases
         prevented_patterns: list of prevented patterns (default 4N)
         k_init: initial guess for SSM k value
+        verbose: bool, True if print statements are desired
     
     Returns:
         list of strings : seqs
@@ -76,14 +77,15 @@ def max_orthogonality(N, L, alphabet="ACT", RCfree=False, GClims=None,
         k_init = max(int(math.log(N)/math.log(len(alphabet))), 2)
     
     while True:
-
-        print("Attempting SSM k=%d" %k_init)
+        if verbose:
+            print("Attempting SSM k=%d" %k_init)
 
         library = max_size(L, k_init, alphabet, RCfree, GClims, prevented_patterns)
 
         if len(library)>N:
-            print("Number of sequences: %d" % len(library))
-            print("SSM k value: %d" % k_init)
+            if verbose:
+                print("Number of sequences: %d" % len(library))
+                print("SSM k value: %d" % k_init)
             return library
 
         k_init += 1


### PR DESCRIPTION
I made a simple change by adding a `verbose` option to the `design.max_orthogonality` function. This allows users to control whether the attempted k_value is printed on the screen during execution. By default, this is set to `True`, so existing behaviour remains unchanged unless the user opts in.
Additionally, I updated the version number in the pyproject.toml to reflect this.
Summary of Changes:
- Added a verbose parameter to the design.max_orthogonality function.
- Updated the version number in pyproject.toml to indicate this new feature.
